### PR TITLE
pump custom metrics default value

### DIFF
--- a/pumps/prometheus.go
+++ b/pumps/prometheus.go
@@ -393,6 +393,19 @@ func (pm *PrometheusMetric) GetLabelsValues(decoded analytics.AnalyticsRecord) [
 	for _, label := range pm.Labels {
 		if val, ok := mapping[label]; ok {
 			values = append(values, fmt.Sprint(val))
+		}else{
+			// log.Info(label)
+			val = "UNKNOWN"
+			for _, tag := range decoded.Tags{
+				prefixString := label + "-"
+				if strings.HasPrefix(tag,prefixString){
+					val = tag[len(prefixString):]
+					break
+				}
+			}
+			if label != "type" {
+				values = append(values, fmt.Sprint(val))
+			}
 		}
 	}
 	return values


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Prometheus custom metrics giving error when custom tags are introduced as part of custom metric labels.
Example : We had a usecase where we need a custom metrics where a custom Label should also be coming as part of prometheus custom metric. But if the custom label is not defined then the pump gives an error. 
Solution :  added a default value "UNKNOWN" of all the custom labels.

## Related Issue
<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->

## How This Has Been Tested
Tested in local by recreating tyk in local by adding custom metric. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
